### PR TITLE
Remove MYSQL_USER and MYSQL_PASSWORD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
    container_name: jackhammer-db
    environment:
      MYSQL_ROOT_PASSWORD: root
-     MYSQL_USER: root
-     MYSQL_PASSWORD: root
      MYSQL_DATABASE: jackhammer_production
    ports:
      - "3306:3306"


### PR DESCRIPTION
The root user is created by default and the password of the root
user is specified by MYSQL_ROOT_PASSWORD.

ref. https://github.com/docker-library/docs/blob/d8a125c55145a3772e4793a1f6bb53c734b44ced/mysql/README.md#mysql_user-mysql_password